### PR TITLE
Update init.lua

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -17,5 +17,11 @@ autocmd("BufUnload", {
    end,
 })
 
+-- Don't auto commenting new lines
+autocmd('BufEnter', {
+  pattern = '*',
+  command = 'set fo-=c fo-=r fo-=o'
+})
+
 -- load statusline
 vim.opt.statusline = "%!v:lua.require'ui.statusline'.run()"


### PR DESCRIPTION
Added a autocmd to prevent comment on new line.

```lua
-- Don't auto commenting new lines
autocmd('BufEnter', {
  pattern = '*',
  command = 'set fo-=c fo-=r fo-=o'
})
```